### PR TITLE
change 'localhost' to '127.0.0.1'

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -8,7 +8,7 @@ export default {
             blockGasLimit: 12000000,
         },
         local: {
-            url: 'http://localhost:8545',
+            url: 'http://127.0.0.1:8545',
             blockGasLimit: 12000000,
             accounts: [
                 '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -1,9 +1,9 @@
 import { spawn, exec } from 'child_process'
 import fetch from 'node-fetch'
 console.log('Starting a hardhat node...')
-const providerURL = `http://localhost:8545`
-const serverURL = `http://localhost:8000`
-const frontendURL = `http://localhost:3000`
+const providerURL = `http://127.0.0.1:8545`
+const serverURL = `http://127.0.0.1:8000`
+const frontendURL = `http://127.0.0.1:3000`
 
 const hardhat = spawn('yarn contracts hardhat node', { shell: true })
 hardhat.stderr.on('data', (data) => {


### PR DESCRIPTION
In node 17+ they changed dns resolution to prefer ipv6 over ipv4. The problem is, they don't respect the order in which host rules are defined, so the resolution is defaulting to :: instead of 127.0.0.1. So the ipv4 address needs to be manually specified, changing every occurrence of localhost to 127.0.0.1

This should be fixed before create-unirep-app workshop this weekend.