### PR TITLE
fix(frontend): intial UI fix for Invalid Proofs

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -289,16 +289,24 @@ export default observer(() => {
                         <div style={{ margin: '20px 0 20px' }}>
                             <Button
                                 onClick={async () => {
-                                    const proof = await userContext.proveData(
-                                        proveData
-                                    )
-                                    setRepProof(proof)
+                                    try {
+                                        const proof =
+                                            await userContext.proveData(
+                                                proveData
+                                            )
+                                        setRepProof(proof)
+                                    } catch (error) {
+                                        console.log(error)
+                                        alert(
+                                            'Invalid Proof. You are attempting to prove more data than you have received. Check your provable data, transition if necessary, and try again'
+                                        )
+                                    }
                                 }}
                             >
                                 Generate Proof
                             </Button>
                         </div>
-                        {repProof.proof.length ? (
+                        {repProof.valid ? (
                             <>
                                 <div>
                                     Is proof valid?{' '}


### PR DESCRIPTION
Solving issue #37 with a simple `alert()`. 

Some feedback received at the Hackathon about CUA was that it was unclear for developers to understand that the proofs they were making were invalid on the Dashboard because the true proof persists after making an Invalid Proof. 

The alert is a simple method to add more context.