### PR TITLE
feat: Fix gitignore to prevent ignoring config.ts files in subdirecto…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 
 .DS_Store
-config.ts
+/config.ts


### PR DESCRIPTION
## Summary

This PR fixes the issue of .gitignore inadvertently ignoring all config.ts files, including those in subdirectories. It also reintroduces the following files:

* packages/frontend/src/config.ts
* packages/relay/src/config.ts

## Details

In the .gitignore file to prevent the ignoring of config.ts files in subdirectories.
Modify 
```
config.ts
```
to 
```
/config.ts
```

## Impacted Areas

* packages/frontend/src/config.ts
* packages/relay/src/config.ts

## Tests

```
yarn build
yarn contracts hardhat node
yarn contracts deploy
yarn relay start
yarn frontend start
```

## Possible Impacts

None foreseen.

## Visual Materials

None.

## Verification Steps
1. Can add ```packages/frontend/src/config.ts``` and ```packages/relay/src/config.ts```
2. Check that Git can now track these files as the ```.gitignore``` no longer ignores them.

## Todo

None

## Checklist

-   [x] Can add ```packages/frontend/src/config.ts``` and ```packages/relay/src/config.ts``` to git 
-   [x] frontend and relay can success run 
