### PR TITLE
fix(frontend): create a new id instead of using empty string

### DIFF
--- a/packages/frontend/src/contexts/User.ts
+++ b/packages/frontend/src/contexts/User.ts
@@ -23,8 +23,8 @@ class User {
     }
 
     async load() {
-        const id: string = localStorage.getItem('id') ?? ''
-        const identity = new Identity(id)
+        const id = localStorage.getItem('id')
+        const identity = id ? new Identity(id) : new Identity()
         if (!id) {
             localStorage.setItem('id', identity.toString())
         }


### PR DESCRIPTION
Previous behavior:
if cache is cleaned, there is no id in storage, it takes empty string `''` as identity input
and generate an specific id
(and different users might generate the same id)

New behavior:
If there is no id in storage, create a new id