### PR TITLE
fix(frontend): fix user state

### DIFF
--- a/packages/frontend/src/contexts/User.ts
+++ b/packages/frontend/src/contexts/User.ts
@@ -45,7 +45,7 @@ class User {
             attesterId: BigInt(APP_ADDRESS),
             id: identity,
         })
-        await userState.sync.start()
+        await userState.start()
         this.userState = userState
         await userState.waitForSync()
         this.hasSignedUp = await userState.hasSignedUp()


### PR DESCRIPTION
if user start with `sync.start()`, the chain ID will not be set
so it has to start with `userState.start()`